### PR TITLE
implement blame command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Track AI-assisted code changes across your development workflow. An open-source, agent-agnostic provenance system that helps teams understand AI usage patterns, measure ROI, and maintain code quality.
 
-> **Status**: ✅ Phase 0 complete - Core foundation with session management! ✅ Phase 2A complete - Claude Code hooks capturing! ✅ Phase 4 Features 1-4 complete - Sessions, statistics, export, and **git commit correlation** with confidence scoring! See `ROADMAP.md` for development plans.
+> **Status**: ✅ Phase 0 complete - Core foundation with session management! ✅ Phase 2A complete - Claude Code hooks capturing! ✅ Phase 4 Features 1-5 complete - Sessions, statistics, export, **git commit correlation** with confidence scoring, and **git blame**! See `ROADMAP.md` for development plans.
 
 ## Quick Start
 
@@ -169,6 +169,47 @@ Once the daemon is running and capturing events, you can query them:
 ./prov search "authentication"
 ```
 
+### Trace Commits to AI Prompts (Blame)
+
+Find out which AI prompts led to specific code changes in your repository:
+
+```bash
+# Blame a commit (supports full or short SHA)
+./prov blame abc123def456
+./prov blame abc123  # Short SHA works too
+
+# Blame a file to see all AI prompts that modified it
+./prov blame src/auth.go
+./prov blame internal/handlers/user.go
+```
+
+**Example output:**
+```
+Found 1 prompt(s) that led to changes:
+
+[1] Commit: abc123def456 (Confidence: 0.95 / 95%)
+    Prompt ID: prompt-blame-1
+    Timestamp: 2026-01-15 17:35:11
+    Agent: claude-code
+    Author: testuser
+    Prompt: Implement user authentication
+    Files Changed:
+      - auth.go
+      - auth_test.go
+    Diff: +150 -20
+```
+
+**Use cases:**
+- **Code review**: See which AI prompts generated specific commits
+- **Debugging**: Trace bugs back to the original AI conversation
+- **Learning**: Understand how specific features were built
+- **Audit**: Track AI contributions to your codebase
+- **Documentation**: Link code changes to their requirements/context
+
+**Requirements:**
+- Git repository with `post-commit` hook installed (see "Link Commits to AI Prompts")
+- At least one commit made after installing the hook
+
 ### Export Session Data
 
 Export your AI interaction data to CSV or JSON for analysis, reporting, or integration with other tools:
@@ -309,6 +350,14 @@ go build -o prov ./cmd/prov
 # Export your session data
 ./prov export --format csv --output my-ai-sessions.csv
 ./prov export --format json --output my-ai-sessions.json
+
+# After making a commit, blame it to see which prompts generated it
+git add .
+git commit -m "Add authentication feature"
+./prov blame HEAD  # or use the commit SHA
+
+# Blame a specific file to see its AI history
+./prov blame src/auth.go
 ```
 
 ### With CLI Tools

--- a/cmd/prov/blame_test.go
+++ b/cmd/prov/blame_test.go
@@ -1,0 +1,443 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/albachteng/provenance/internal/storage"
+)
+
+// TestBlameCommit tests blaming a specific commit SHA
+func TestBlameCommit(t *testing.T) {
+	tmpDir := setupTestEnv(t)
+	db := setupTestDB(t, tmpDir)
+	defer db.Close()
+
+	// Create test data: session -> prompt -> change_set
+	session := &storage.Session{
+		ID:        "session-blame-1",
+		StartTime: time.Now(),
+		RepoPath:  "/test/repo",
+	}
+	if err := storage.CreateSession(db, session); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	prompt := &storage.PromptEvent{
+		ID:             "prompt-blame-1",
+		Timestamp:      time.Now(),
+		SessionID:      "session-blame-1",
+		Agent:          "claude-code",
+		PromptText:     "Implement user authentication",
+		RepoPath:       "/test/repo",
+		Author:         "testuser",
+		FilesMentioned: []string{"auth.go", "auth_test.go"},
+	}
+	if err := storage.StorePromptEvent(db, prompt); err != nil {
+		t.Fatalf("Failed to store prompt: %v", err)
+	}
+
+	changeSet := &storage.ChangeSet{
+		ID:                "cs-blame-1",
+		PromptID:          "prompt-blame-1",
+		SessionID:         "session-blame-1",
+		Timestamp:         time.Now(),
+		FilesChanged:      []string{"auth.go", "auth_test.go"},
+		DiffSummary:       "+150 -20",
+		CommitIntroduced:  "abc123def456",
+		CorrelationMethod: "git_hook",
+		Confidence:        0.95,
+	}
+	if err := storage.CreateChangeSet(db, changeSet); err != nil {
+		t.Fatalf("Failed to create change set: %v", err)
+	}
+
+	// Run blame command
+	output, err := runCLI(t, "blame", "abc123def456")
+	if err != nil {
+		t.Fatalf("blame command failed: %v\nOutput: %s", err, output)
+	}
+
+	// Should show the linked prompt
+	if !strings.Contains(output, "prompt-blame-1") {
+		t.Errorf("Expected to find prompt ID in output, got: %s", output)
+	}
+
+	if !strings.Contains(output, "Implement user authentication") {
+		t.Errorf("Expected to find prompt text in output, got: %s", output)
+	}
+
+	if !strings.Contains(output, "0.95") || !strings.Contains(output, "95%") {
+		t.Errorf("Expected to find confidence score in output, got: %s", output)
+	}
+
+	if !strings.Contains(output, "auth.go") {
+		t.Errorf("Expected to find changed files in output, got: %s", output)
+	}
+}
+
+// TestBlameCommitNoMatches tests blaming a commit with no correlations
+func TestBlameCommitNoMatches(t *testing.T) {
+	tmpDir := setupTestEnv(t)
+	db := setupTestDB(t, tmpDir)
+	defer db.Close()
+
+	output, err := runCLI(t, "blame", "nonexistent-commit-sha")
+	if err != nil {
+		t.Fatalf("blame command failed: %v", err)
+	}
+
+	// Should indicate no prompts found
+	if !strings.Contains(output, "No prompts found") && !strings.Contains(output, "no correlations") {
+		t.Errorf("Expected 'no prompts found' message, got: %s", output)
+	}
+}
+
+// TestBlameCommitMultiplePrompts tests a commit linked to multiple prompts
+func TestBlameCommitMultiplePrompts(t *testing.T) {
+	tmpDir := setupTestEnv(t)
+	db := setupTestDB(t, tmpDir)
+	defer db.Close()
+
+	// Create test data with 2 prompts for same commit
+	session := &storage.Session{
+		ID:        "session-multi-1",
+		StartTime: time.Now(),
+		RepoPath:  "/test/repo",
+	}
+	if err := storage.CreateSession(db, session); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	prompt1 := &storage.PromptEvent{
+		ID:             "prompt-multi-1",
+		Timestamp:      time.Now().Add(-5 * time.Minute),
+		SessionID:      "session-multi-1",
+		Agent:          "claude-code",
+		PromptText:     "Add login functionality",
+		RepoPath:       "/test/repo",
+		Author:         "testuser",
+		FilesMentioned: []string{"login.go"},
+	}
+	if err := storage.StorePromptEvent(db, prompt1); err != nil {
+		t.Fatalf("Failed to store prompt1: %v", err)
+	}
+
+	prompt2 := &storage.PromptEvent{
+		ID:             "prompt-multi-2",
+		Timestamp:      time.Now().Add(-3 * time.Minute),
+		SessionID:      "session-multi-1",
+		Agent:          "claude-code",
+		PromptText:     "Add logout functionality",
+		RepoPath:       "/test/repo",
+		Author:         "testuser",
+		FilesMentioned: []string{"logout.go"},
+	}
+	if err := storage.StorePromptEvent(db, prompt2); err != nil {
+		t.Fatalf("Failed to store prompt2: %v", err)
+	}
+
+	changeSet1 := &storage.ChangeSet{
+		ID:                "cs-multi-1",
+		PromptID:          "prompt-multi-1",
+		SessionID:         "session-multi-1",
+		Timestamp:         time.Now(),
+		FilesChanged:      []string{"login.go"},
+		CommitIntroduced:  "shared-commit-abc",
+		CorrelationMethod: "git_hook",
+		Confidence:        0.90,
+	}
+	if err := storage.CreateChangeSet(db, changeSet1); err != nil {
+		t.Fatalf("Failed to create change set 1: %v", err)
+	}
+
+	changeSet2 := &storage.ChangeSet{
+		ID:                "cs-multi-2",
+		PromptID:          "prompt-multi-2",
+		SessionID:         "session-multi-1",
+		Timestamp:         time.Now(),
+		FilesChanged:      []string{"logout.go"},
+		CommitIntroduced:  "shared-commit-abc",
+		CorrelationMethod: "git_hook",
+		Confidence:        0.85,
+	}
+	if err := storage.CreateChangeSet(db, changeSet2); err != nil {
+		t.Fatalf("Failed to create change set 2: %v", err)
+	}
+
+	// Run blame command
+	output, err := runCLI(t, "blame", "shared-commit-abc")
+	if err != nil {
+		t.Fatalf("blame command failed: %v", err)
+	}
+
+	// Should show both prompts
+	if !strings.Contains(output, "Add login functionality") {
+		t.Errorf("Expected to find first prompt in output, got: %s", output)
+	}
+
+	if !strings.Contains(output, "Add logout functionality") {
+		t.Errorf("Expected to find second prompt in output, got: %s", output)
+	}
+
+	// Should be ordered by confidence (highest first)
+	loginIdx := strings.Index(output, "Add login")
+	logoutIdx := strings.Index(output, "Add logout")
+	if loginIdx == -1 || logoutIdx == -1 {
+		t.Fatalf("Could not find both prompts in output")
+	}
+	if loginIdx > logoutIdx {
+		t.Errorf("Expected prompts ordered by confidence (highest first), but got login after logout")
+	}
+}
+
+// TestBlameFile tests blaming a file path
+func TestBlameFile(t *testing.T) {
+	tmpDir := setupTestEnv(t)
+	db := setupTestDB(t, tmpDir)
+	defer db.Close()
+
+	// Create test data
+	session := &storage.Session{
+		ID:        "session-file-1",
+		StartTime: time.Now(),
+		RepoPath:  "/test/repo",
+	}
+	if err := storage.CreateSession(db, session); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	prompt := &storage.PromptEvent{
+		ID:             "prompt-file-1",
+		Timestamp:      time.Now(),
+		SessionID:      "session-file-1",
+		Agent:          "claude-code",
+		PromptText:     "Refactor authentication module",
+		RepoPath:       "/test/repo",
+		Author:         "testuser",
+		FilesMentioned: []string{"internal/auth/auth.go"},
+	}
+	if err := storage.StorePromptEvent(db, prompt); err != nil {
+		t.Fatalf("Failed to store prompt: %v", err)
+	}
+
+	changeSet := &storage.ChangeSet{
+		ID:                "cs-file-1",
+		PromptID:          "prompt-file-1",
+		SessionID:         "session-file-1",
+		Timestamp:         time.Now(),
+		FilesChanged:      []string{"internal/auth/auth.go", "internal/auth/auth_test.go"},
+		CommitIntroduced:  "file-commit-123",
+		CorrelationMethod: "git_hook",
+		Confidence:        0.88,
+	}
+	if err := storage.CreateChangeSet(db, changeSet); err != nil {
+		t.Fatalf("Failed to create change set: %v", err)
+	}
+
+	// Run blame command on file
+	output, err := runCLI(t, "blame", "internal/auth/auth.go")
+	if err != nil {
+		t.Fatalf("blame command failed: %v\nOutput: %s", err, output)
+	}
+
+	// Should show the linked prompt
+	if !strings.Contains(output, "Refactor authentication module") {
+		t.Errorf("Expected to find prompt text in output, got: %s", output)
+	}
+
+	if !strings.Contains(output, "file-commit-123") {
+		t.Errorf("Expected to find commit SHA in output, got: %s", output)
+	}
+
+	if !strings.Contains(output, "0.88") || !strings.Contains(output, "88%") {
+		t.Errorf("Expected to find confidence score in output, got: %s", output)
+	}
+}
+
+// TestBlameFileNoMatches tests blaming a file with no correlations
+func TestBlameFileNoMatches(t *testing.T) {
+	tmpDir := setupTestEnv(t)
+	db := setupTestDB(t, tmpDir)
+	defer db.Close()
+
+	output, err := runCLI(t, "blame", "nonexistent/file.go")
+	if err != nil {
+		t.Fatalf("blame command failed: %v", err)
+	}
+
+	// Should indicate no prompts found
+	if !strings.Contains(output, "No prompts found") && !strings.Contains(output, "no correlations") {
+		t.Errorf("Expected 'no prompts found' message, got: %s", output)
+	}
+}
+
+// TestBlameFileMultipleCommits tests a file touched by multiple commits
+func TestBlameFileMultipleCommits(t *testing.T) {
+	tmpDir := setupTestEnv(t)
+	db := setupTestDB(t, tmpDir)
+	defer db.Close()
+
+	// Create test data with same file in multiple commits
+	session := &storage.Session{
+		ID:        "session-file-multi",
+		StartTime: time.Now(),
+		RepoPath:  "/test/repo",
+	}
+	if err := storage.CreateSession(db, session); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	// First prompt/commit
+	prompt1 := &storage.PromptEvent{
+		ID:             "prompt-file-m1",
+		Timestamp:      time.Now().Add(-10 * time.Minute),
+		SessionID:      "session-file-multi",
+		Agent:          "claude-code",
+		PromptText:     "Initial implementation of handler",
+		RepoPath:       "/test/repo",
+		Author:         "testuser",
+		FilesMentioned: []string{"handler.go"},
+	}
+	if err := storage.StorePromptEvent(db, prompt1); err != nil {
+		t.Fatalf("Failed to store prompt1: %v", err)
+	}
+
+	changeSet1 := &storage.ChangeSet{
+		ID:                "cs-file-m1",
+		PromptID:          "prompt-file-m1",
+		SessionID:         "session-file-multi",
+		Timestamp:         time.Now().Add(-9 * time.Minute),
+		FilesChanged:      []string{"handler.go"},
+		CommitIntroduced:  "commit-1",
+		CorrelationMethod: "git_hook",
+		Confidence:        0.92,
+	}
+	if err := storage.CreateChangeSet(db, changeSet1); err != nil {
+		t.Fatalf("Failed to create change set 1: %v", err)
+	}
+
+	// Second prompt/commit
+	prompt2 := &storage.PromptEvent{
+		ID:             "prompt-file-m2",
+		Timestamp:      time.Now().Add(-5 * time.Minute),
+		SessionID:      "session-file-multi",
+		Agent:          "claude-code",
+		PromptText:     "Add error handling to handler",
+		RepoPath:       "/test/repo",
+		Author:         "testuser",
+		FilesMentioned: []string{"handler.go"},
+	}
+	if err := storage.StorePromptEvent(db, prompt2); err != nil {
+		t.Fatalf("Failed to store prompt2: %v", err)
+	}
+
+	changeSet2 := &storage.ChangeSet{
+		ID:                "cs-file-m2",
+		PromptID:          "prompt-file-m2",
+		SessionID:         "session-file-multi",
+		Timestamp:         time.Now().Add(-4 * time.Minute),
+		FilesChanged:      []string{"handler.go"},
+		CommitIntroduced:  "commit-2",
+		CorrelationMethod: "git_hook",
+		Confidence:        0.87,
+	}
+	if err := storage.CreateChangeSet(db, changeSet2); err != nil {
+		t.Fatalf("Failed to create change set 2: %v", err)
+	}
+
+	// Run blame command on file
+	output, err := runCLI(t, "blame", "handler.go")
+	if err != nil {
+		t.Fatalf("blame command failed: %v", err)
+	}
+
+	// Should show both prompts
+	if !strings.Contains(output, "Initial implementation") {
+		t.Errorf("Expected to find first prompt in output, got: %s", output)
+	}
+
+	if !strings.Contains(output, "Add error handling") {
+		t.Errorf("Expected to find second prompt in output, got: %s", output)
+	}
+
+	// Should show both commits
+	if !strings.Contains(output, "commit-1") {
+		t.Errorf("Expected to find commit-1 in output, got: %s", output)
+	}
+
+	if !strings.Contains(output, "commit-2") {
+		t.Errorf("Expected to find commit-2 in output, got: %s", output)
+	}
+}
+
+// TestBlameNoArgument tests blame with no file/commit specified
+func TestBlameNoArgument(t *testing.T) {
+	tmpDir := setupTestEnv(t)
+	setupTestDB(t, tmpDir)
+
+	output, err := runCLI(t, "blame")
+	if err == nil {
+		t.Error("Expected error when no argument provided")
+	}
+
+	// Error message should indicate usage
+	if !strings.Contains(output, "Usage") || !strings.Contains(output, "blame") {
+		t.Errorf("Expected usage error in output, got: %s", output)
+	}
+}
+
+// TestBlameShortCommitSHA tests blaming with a short commit SHA
+func TestBlameShortCommitSHA(t *testing.T) {
+	tmpDir := setupTestEnv(t)
+	db := setupTestDB(t, tmpDir)
+	defer db.Close()
+
+	// Create test data with full SHA
+	session := &storage.Session{
+		ID:        "session-short-sha",
+		StartTime: time.Now(),
+		RepoPath:  "/test/repo",
+	}
+	if err := storage.CreateSession(db, session); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	prompt := &storage.PromptEvent{
+		ID:         "prompt-short-sha",
+		Timestamp:  time.Now(),
+		SessionID:  "session-short-sha",
+		Agent:      "claude-code",
+		PromptText: "Short SHA test",
+		RepoPath:   "/test/repo",
+		Author:     "testuser",
+	}
+	if err := storage.StorePromptEvent(db, prompt); err != nil {
+		t.Fatalf("Failed to store prompt: %v", err)
+	}
+
+	changeSet := &storage.ChangeSet{
+		ID:                "cs-short-sha",
+		PromptID:          "prompt-short-sha",
+		SessionID:         "session-short-sha",
+		Timestamp:         time.Now(),
+		FilesChanged:      []string{"test.go"},
+		CommitIntroduced:  "abc123def456789",
+		CorrelationMethod: "git_hook",
+		Confidence:        0.90,
+	}
+	if err := storage.CreateChangeSet(db, changeSet); err != nil {
+		t.Fatalf("Failed to create change set: %v", err)
+	}
+
+	// Should work with short SHA (prefix match)
+	output, err := runCLI(t, "blame", "abc123")
+	if err != nil {
+		t.Fatalf("blame command failed with short SHA: %v", err)
+	}
+
+	if !strings.Contains(output, "Short SHA test") {
+		t.Errorf("Expected to find prompt with short SHA, got: %s", output)
+	}
+}

--- a/cmd/prov/commands.go
+++ b/cmd/prov/commands.go
@@ -1759,3 +1759,77 @@ func escapeCSV(field string) string {
 	}
 	return field
 }
+
+// cmdBlame shows which AI prompts led to changes in a commit or file
+func cmdBlame() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "Usage: prov blame <commit-sha|file-path>")
+		os.Exit(1)
+	}
+
+	target := os.Args[2]
+
+	db, err := openDB()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to open database: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close() //nolint:errcheck
+
+	var changeSets []*storage.ChangeSet
+	changeSets, err = storage.GetChangeSetsForCommitPrefix(db, target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to query change sets: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(changeSets) == 0 {
+		changeSets, err = storage.GetChangeSetsForFile(db, target)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to query change sets: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	if len(changeSets) == 0 {
+		fmt.Println("No prompts found for this commit or file")
+		return
+	}
+
+	fmt.Printf("Found %d prompt(s) that led to changes:\n\n", len(changeSets))
+
+	for i, cs := range changeSets {
+		prompt, err := storage.GetPromptEvent(db, cs.PromptID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to get prompt %s: %v\n", cs.PromptID, err)
+			continue
+		}
+
+		fmt.Printf("[%d] Commit: %s (Confidence: %.2f / %.0f%%)\n", i+1, cs.CommitIntroduced, cs.Confidence, cs.Confidence*100)
+		fmt.Printf("    Prompt ID: %s\n", prompt.ID)
+		fmt.Printf("    Timestamp: %s\n", prompt.Timestamp.Format("2006-01-02 15:04:05"))
+		fmt.Printf("    Agent: %s\n", prompt.Agent)
+		fmt.Printf("    Author: %s\n", prompt.Author)
+		fmt.Printf("    Prompt: %s\n", truncatePrompt(prompt.PromptText, 200))
+
+		if len(cs.FilesChanged) > 0 {
+			fmt.Printf("    Files Changed:\n")
+			for _, file := range cs.FilesChanged {
+				fmt.Printf("      - %s\n", file)
+			}
+		}
+
+		if cs.DiffSummary != "" {
+			fmt.Printf("    Diff: %s\n", cs.DiffSummary)
+		}
+
+		fmt.Println()
+	}
+}
+
+func truncatePrompt(prompt string, maxLen int) string {
+	if len(prompt) <= maxLen {
+		return prompt
+	}
+	return prompt[:maxLen-3] + "..."
+}

--- a/cmd/prov/main.go
+++ b/cmd/prov/main.go
@@ -58,6 +58,8 @@ func main() {
 		cmdStats()
 	case "export":
 		cmdExport()
+	case "blame":
+		cmdBlame()
 	case "help", "--help", "-h":
 		printUsage()
 	default:
@@ -96,6 +98,7 @@ func printUsage() {
 	fmt.Println("  list                 List recent prompts")
 	fmt.Println("  show <id>            Show prompt details")
 	fmt.Println("  search <query>       Search prompts")
+	fmt.Println("  blame <commit|file>  Show which prompts led to changes in a commit or file")
 	fmt.Println()
 	fmt.Println("Run 'prov <command> --help' for more information")
 }

--- a/internal/storage/changesets.go
+++ b/internal/storage/changesets.go
@@ -211,3 +211,119 @@ func GetChangeSetsForCommit(db *sql.DB, commitSHA string) ([]*ChangeSet, error) 
 
 	return changeSets, nil
 }
+
+// GetChangeSetsForCommitPrefix retrieves all change sets matching a commit SHA prefix, ordered by confidence
+func GetChangeSetsForCommitPrefix(db *sql.DB, commitPrefix string) ([]*ChangeSet, error) {
+	query := `
+		SELECT id, prompt_id, session_id, timestamp,
+		       files_changed, diff_summary, commit_introduced,
+		       correlation_method, confidence, time_to_first_change_ms
+		FROM change_sets
+		WHERE commit_introduced LIKE ?
+		ORDER BY confidence DESC
+	`
+
+	rows, err := db.Query(query, commitPrefix+"%")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query change sets: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var changeSets []*ChangeSet
+
+	for rows.Next() {
+		var cs ChangeSet
+		var timestampUnix int64
+		var filesChangedJSON string
+
+		err := rows.Scan(
+			&cs.ID,
+			&cs.PromptID,
+			&cs.SessionID,
+			&timestampUnix,
+			&filesChangedJSON,
+			&cs.DiffSummary,
+			&cs.CommitIntroduced,
+			&cs.CorrelationMethod,
+			&cs.Confidence,
+			&cs.TimeToFirstChangeMs,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan change set: %w", err)
+		}
+
+		cs.Timestamp = time.Unix(timestampUnix, 0)
+
+		if err := json.Unmarshal([]byte(filesChangedJSON), &cs.FilesChanged); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal files_changed: %w", err)
+		}
+
+		changeSets = append(changeSets, &cs)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating change sets: %w", err)
+	}
+
+	return changeSets, nil
+}
+
+// GetChangeSetsForFile retrieves all change sets that modified a specific file, ordered by confidence
+func GetChangeSetsForFile(db *sql.DB, filePath string) ([]*ChangeSet, error) {
+	query := `
+		SELECT id, prompt_id, session_id, timestamp,
+		       files_changed, diff_summary, commit_introduced,
+		       correlation_method, confidence, time_to_first_change_ms
+		FROM change_sets
+		ORDER BY confidence DESC
+	`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query change sets: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var changeSets []*ChangeSet
+
+	for rows.Next() {
+		var cs ChangeSet
+		var timestampUnix int64
+		var filesChangedJSON string
+
+		err := rows.Scan(
+			&cs.ID,
+			&cs.PromptID,
+			&cs.SessionID,
+			&timestampUnix,
+			&filesChangedJSON,
+			&cs.DiffSummary,
+			&cs.CommitIntroduced,
+			&cs.CorrelationMethod,
+			&cs.Confidence,
+			&cs.TimeToFirstChangeMs,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan change set: %w", err)
+		}
+
+		cs.Timestamp = time.Unix(timestampUnix, 0)
+
+		if err := json.Unmarshal([]byte(filesChangedJSON), &cs.FilesChanged); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal files_changed: %w", err)
+		}
+
+		for _, file := range cs.FilesChanged {
+			if file == filePath {
+				changeSets = append(changeSets, &cs)
+				break
+			}
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating change sets: %w", err)
+	}
+
+	return changeSets, nil
+}


### PR DESCRIPTION
* adds the `prov blame <hash|file>` command
* git hook associates commits with change sets and prompt data
* blame command displays prompts and change sets associated with the given commit or file